### PR TITLE
Add dev-secure-cc badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,5 @@
 
 
 [![CI](https://github.com/nanddeepn/DemoRepo/actions/workflows/blank.yml/badge.svg)](https://github.com/nanddeepn/DemoRepo/actions/workflows/blank.yml)
+
+dev-secure-cc


### PR DESCRIPTION
This pull request makes a minor update to the `README.md` file by adding the text "dev-secure-cc" at the end of the document.

Resolved: [AB#2](https://dev.azure.com/nanddeepnachan0785/5e4d3000-d851-4c13-af17-914628f7ab3f/_workitems/edit/2)